### PR TITLE
Fix wrong json export with linked, trimmed cels (fix #2600)

### DIFF
--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2022  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -390,18 +390,13 @@ public:
         return;
       token.set_progress(0.2f + 0.2f * i / samples.size());
 
-      if (sample.isLinked()) {
-        ++i;
-        continue;
-      }
-
       if (sample.isEmpty()) {
         sample.setInTextureBounds(gfx::Rect(0, 0, 0, 0));
         ++i;
         continue;
       }
 
-      if (m_mergeDups) {
+      if (m_mergeDups || sample.isLinked()) {
         doc::ImageBufferPtr sampleBuf = std::make_shared<doc::ImageBuffer>();
         doc::ImageRef sampleRender(sample.createRender(sampleBuf));
         auto it = duplicates.find(sampleRender);
@@ -527,8 +522,7 @@ public:
       token.set_progress_range(0.2f, 0.3f);
       token.set_progress(float(i) / samples.size());
 
-      if (sample.isLinked() ||
-          sample.isEmpty()) {
+      if (sample.isEmpty()) {
         ++i;
         continue;
       }
@@ -923,7 +917,10 @@ void DocExporter::captureSamples(Samples& samples,
             ASSERT(!other.isLinked());
 
             sample.setLinked();
-            sample.setSharedBounds(other.sharedBounds());
+            if (m_splitLayers)
+              sample.setTrimmedBounds(other.trimmedBounds());
+            else
+              sample.setSharedBounds(other.sharedBounds());
             done = true;
             break;
           }
@@ -1000,7 +997,7 @@ void DocExporter::captureSamples(Samples& samples,
           alreadyTrimmed = true;
         }
       }
-      if (!alreadyTrimmed && m_trimSprite)
+      if (!alreadyTrimmed && m_trimSprite && !m_splitLayers)
         sample.setTrimmedBounds(spriteBounds);
 
       samples.addSample(sample);


### PR DESCRIPTION
Before this fix, the json file associated with the exported sprite sheet had wrong 'spriteSourceSize' coordinates in particular cases like this:
- Linked cels
- Export Sprite Sheet options: TrimmedCels + Merge Duplicates + SplitLayers checked

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V3.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
